### PR TITLE
Wrap Around

### DIFF
--- a/src/components/TravelLogMap.tsx
+++ b/src/components/TravelLogMap.tsx
@@ -84,7 +84,7 @@ export default function TravelLogMap({ logs }: TravelLogMapProps) {
     [state.map, dispatch]
   );
   return (
-    <MapContainer className="w-full h-full" style={{ background: '#242525' }}>
+    <MapContainer worldCopyJump={true} className="w-full h-full" style={{ background: '#242525' }}>
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url={process.env.NEXT_PUBLIC_MAP_TILE_URL || ''}


### PR DESCRIPTION
Added `worldCopyJump={true}` to the `MapContainer`

This makes it so if someone scrolls the map to the West or East all the pins "Wrap around" as they disappear from view.

This also prevents if someone scrolls the view and clicks to add a pin, you can end up with coordinates that look like `38.548165, -466.611328` (notice the longitude value)

This property is not documented in https://react-leaflet.js.org/docs/api-map/ but it is documented in Leaflet https://leafletjs.com/reference.html#map-worldcopyjump