### PR TITLE
Fix wrong date in popup

### DIFF
--- a/src/components/TravelLogMap.tsx
+++ b/src/components/TravelLogMap.tsx
@@ -123,7 +123,9 @@ export default function TravelLogMap({ logs }: TravelLogMapProps) {
             </div>
             <p>{log.description}</p>
             <p className="text-sm italic">
-              {new Date(log.visitDate).toLocaleDateString()}
+              {new Date(log.visitDate).toLocaleDateString(undefined, {
+                timeZone: 'UTC',
+              })}
             </p>
           </Popup>
         </Marker>


### PR DESCRIPTION
It was showing the wrong date on popup the timestamp is from `06/01/2023` but it was showing as  `5/31/2023` 

<img width="276" alt="image" src="https://user-images.githubusercontent.com/4560552/222009136-3441390b-9c26-4eae-99c2-096ef47459f8.png">
