### PR TITLE
Wrap coordinates fix

### DIFF
--- a/src/components/TravelLogMap.tsx
+++ b/src/components/TravelLogMap.tsx
@@ -74,11 +74,11 @@ export default function TravelLogMap({ logs }: TravelLogMapProps) {
       });
       dispatch({
         type: TravelLogActionType.SET_CURRENT_MARKER_LOCATION,
-        data: e.latlng,
+        data: e.latlng.wrap(),
       });
       if (state.map) {
         const zoomLevel = state.map.getZoom();
-        state.map.flyTo(e.latlng, zoomLevel > 5 ? zoomLevel : 5);
+        state.map.flyTo(e.latlng.wrap(), zoomLevel > 5 ? zoomLevel : 5);
       }
     },
     [state.map, dispatch]
@@ -101,7 +101,7 @@ export default function TravelLogMap({ logs }: TravelLogMapProps) {
             dragend(e) {
               dispatch({
                 type: TravelLogActionType.SET_CURRENT_MARKER_LOCATION,
-                data: e.target.getLatLng(),
+                data: e.target.getLatLng().wrap(),
               });
             },
           }}


### PR DESCRIPTION
To see what this is fixing, zoom way out on the current map and click either way East or way West. Notice the coordinates, specially the Latitude. Also drag the added marker while zoomed out from one end of the map to the other.

This fix will wrap the coordinates to be always within the allowed range.

More about wrap: https://leafletjs.com/reference.html#latlng-wrap

Notice: It will happen that we may click on X point in the map when zoomed out, and the marker be placed in the "equivalent" spot if the same is closer to the center on the map.